### PR TITLE
Fix generation of "sombok" makefile

### DIFF
--- a/Makefile.PL.sombok
+++ b/Makefile.PL.sombok
@@ -66,13 +66,11 @@ sombok/libsombok.a:
 sub MY::c_o {
     package MY;
     my $self = shift;
+    # Have c -> o suffix rules specify the location of the object file. This
+    # keeps the source file and the corresponding object file in the same
+    # directory, without having to rewrite the suffix rules
+    local $self->{XSMULTI} = 1;
     my $inherited = $self->SUPER::c_o(@_);
-    $inherited =~ s{(:\n\t)(.*(?:\n\t.*)*)}
-	{ $1 . $self->cd('lib', split /(?<!\\)\n\t/, $2) }eg;
-    $inherited =~ s{(\s)(\$\*\.c\s)}
-	{ "$1..\$(DIRFILESEP)$2" }eg;
-    $inherited =~ s{(-o\s)(\$\*\$\(OBJ_EXT\))}
-	{ "$1..\$(DIRFILESEP)$2" }eg;
     $inherited;
 }
 


### PR DESCRIPTION
Starting with ExtUtils-MakeMaker v7.35_05 (Perl 5.31.1 and later), makefiles generated for MSVC specify the path to the pdb file as the makefile 'stem' ($*) of the object file being compiled ('.o' extension is replaced with '.pdb'. (this allows parallel compilation). However, Unicode-LineBreak's "sombok" makefile generator incompletely rewrites the suffix rules generated by MakeMaker to attempt to account for the sombok library's code layout. This results in MSVC attempting to write to a non-existant path (cannot open program database '...\sombok\lib\lib\break.pdb').

Instead of attempting to write another substitution pattern for the new 'pdb' paths:
1. remove the rewrites that changes directory and adjusts the paths to the files
2. when calling the MM method that generates the suffix rules, temporarily force on a flag that causes the rules to include the compiler option that specifies the complete path to the object file.

This keeps the derived files in the expected locations.

https://rt.cpan.org/Ticket/Display.html?id=143360